### PR TITLE
prevent direct image downloads

### DIFF
--- a/src/default.scss
+++ b/src/default.scss
@@ -17,6 +17,10 @@ body,
     height: 100%;
 }
 
+img {
+pointer events: none;
+}
+
 body {
     font-family: 'Roboto', sans-serif;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
setting pointer-events to none for all images will prevent visitors from downloading them directly